### PR TITLE
Feature/optional restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The only goal of this plugin, it will:
 | contextRoot				| String	| **required** for war deployment                   														|
 | sharedLibs				| String	| Bind the exist shared libs to ear/war, comma-separated (,)												|
 | parentLast				| Boolean	| `true` to set classloader mode of application to `PARENT_LAST`, default `false`							|
+| restartAfterDeploy		| Boolean	| `true` to restart server after deploy, default `true`							|
 | webModuleParentLast		| Boolean	| `true` to set classloader mode of web module to `PARENT_LAST`, default `false`							|
 | **packageFile**			| String	| The EAR/WAR package that will be deployed to remote RAS, Default: `${project.artifact.file}`				|
 | **failOnError**			| Boolean	| Default: `false` Whether failed the build when failed to deploy.                          				|

--- a/src/main/java/com/orctom/mojo/was/AbstractWASMojo.java
+++ b/src/main/java/com/orctom/mojo/was/AbstractWASMojo.java
@@ -47,7 +47,7 @@ public abstract class AbstractWASMojo extends AbstractMojo {
     @Parameter
     protected String connectorType;
 
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "true")
     protected boolean restartAfterDeploy;
 
     /**

--- a/src/main/java/com/orctom/mojo/was/AbstractWASMojo.java
+++ b/src/main/java/com/orctom/mojo/was/AbstractWASMojo.java
@@ -47,6 +47,9 @@ public abstract class AbstractWASMojo extends AbstractMojo {
     @Parameter
     protected String connectorType;
 
+    @Parameter(defaultValue = "false")
+    protected boolean restartAfterDeploy;
+
     /**
      * Required if target server is a cluster
      */
@@ -173,6 +176,7 @@ public abstract class AbstractWASMojo extends AbstractMojo {
                 .setScriptArgs(scriptArgs)
                 .setJavaoption(javaoption)
                 .setFailOnError(failOnError)
+                .setRestartAfterDeploy(restartAfterDeploy)
                 .setVerbose(verbose);
     	
     	model.setProperties(getProjectProperties());
@@ -216,6 +220,7 @@ public abstract class AbstractWASMojo extends AbstractMojo {
                     .setScriptArgs(scriptArgs)
                     .setJavaoption(javaoption)
                     .setFailOnError(failOnError)
+                    .setRestartAfterDeploy(Boolean.valueOf(getPropertyValue("restartAfterDeploy", props)))
                     .setVerbose(verbose);
 
             model.setProperties(props);
@@ -271,6 +276,7 @@ public abstract class AbstractWASMojo extends AbstractMojo {
         setProperty(properties, "script", script);
         setProperty(properties, "scriptArgs", scriptArgs);
         setProperty(properties, "verbose", String.valueOf(verbose));
+        setProperty(properties, "restartAfterDeploy", String.valueOf(restartAfterDeploy));
 
         properties.setProperty("basedir", project.getBasedir().getAbsolutePath());
         properties.setProperty("project.basedir", project.getBasedir().getAbsolutePath());

--- a/src/main/java/com/orctom/mojo/was/model/WebSphereModel.java
+++ b/src/main/java/com/orctom/mojo/was/model/WebSphereModel.java
@@ -24,6 +24,7 @@ public class WebSphereModel {
     private String contextRoot;
     private String sharedLibs;
     private boolean parentLast;
+    private boolean restartAfterDeploy;
     private boolean webModuleParentLast;
     private String packageFile;
     private String script;
@@ -253,6 +254,15 @@ public class WebSphereModel {
         return this;
     }
 
+    public boolean shouldRestartAfterDeploy() {
+        return restartAfterDeploy;
+    }
+
+    public WebSphereModel setRestartAfterDeploy(boolean restartAfterDeploy) {
+        this.restartAfterDeploy = restartAfterDeploy;
+        return this;
+    }
+
     public Properties getProperties() {
         return properties;
     }
@@ -286,6 +296,7 @@ public class WebSphereModel {
                 ", javaoption='" + javaoption + '\'' +
                 ", failOnError=" + failOnError +
                 ", verbose=" + verbose +
+                ", restartAfterDeploy='" + restartAfterDeploy + '\'' +
                 ", properties=" + properties +
                 '}';
     }

--- a/src/main/resources/jython/websphere.py
+++ b/src/main/resources/jython/websphere.py
@@ -191,6 +191,9 @@ class WebSphere:
         if "true" == self.installApplication():
             if "true" == restartAfterDeploy:
                 self.restartServer()
+            else:
+                print "no reboot just startApplication directly..."
+                self.startApplication()
 
         print '-'*60
         print "[FINISHED]", host, applicationName

--- a/src/main/resources/jython/websphere.py
+++ b/src/main/resources/jython/websphere.py
@@ -15,6 +15,7 @@ sharedLibs = r"{{sharedLibs}}"
 parentLast = r"{{parentLast}}"
 webModuleParentLast = r"{{webModuleParentLast}}"
 packageFile = r"{{packageFile}}"
+restartAfterDeploy = r"{{restartAfterDeploy}}"
 
 class WebSphere:
     def listApplications(self):
@@ -188,7 +189,8 @@ class WebSphere:
             self.uninstallApplication()
 
         if "true" == self.installApplication():
-            self.restartServer()
+            if "true" == restartAfterDeploy:
+                self.restartServer()
 
         print '-'*60
         print "[FINISHED]", host, applicationName


### PR DESCRIPTION
New property restartAfterDeploy.

Default value 'true' to keep original functionality.

When property is set to 'false' plugin will not restart WAS after deploy (only do uninstall + install)
