### PR TITLE
support system property for defining the deployments property file

### DIFF
--- a/src/main/java/com/orctom/mojo/was/AbstractWASMojo.java
+++ b/src/main/java/com/orctom/mojo/was/AbstractWASMojo.java
@@ -29,7 +29,7 @@ public abstract class AbstractWASMojo extends AbstractMojo {
   @Parameter(defaultValue = "${plugin.artifacts}")
   protected List<Artifact> pluginArtifacts;
 
-  @Parameter(defaultValue = "${project.basedir}/was-maven-plugin.properties")
+  @Parameter(defaultValue = "${project.basedir}/was-maven-plugin.properties", property = "was.deploymentsPropertyFile")
   protected File deploymentsPropertyFile;
 
   @Parameter(required = true)


### PR DESCRIPTION
This PR introduces support for defining the deploymentsPropertyFile as a system property (vs requiring it to be defined in the <configuration> section of the plugin in the pom.  As a result, this will allow a consumer to invoke this plugin purely from the command line, removing the need to define it in a pom at all (which can be useful in lots of cases, including CI/CD).  Note that the 'was.' prefix is used to namespace the property.

```bash
mvn clean package com.orctom.mojo:was-maven-plugin:1.1.3.2:deploy -Dwas.deploymentsPropertyFile=src/main/configwas-maven-plugin.properties
```